### PR TITLE
Add option to download by list of tracks or ranges of tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Download music from vk.com
 
 ## Requirements
-Python 3 is required to run this program and *ffmpeg* binary should be in PATH.
+Python 3.6 is required to run this program and *ffmpeg* binary should be in PATH.
 You can install required modules using this command:
 `pip install -r requirements.txt`
 

--- a/vkaudio.py
+++ b/vkaudio.py
@@ -159,7 +159,7 @@ while True:
                     print("Processed block %d/%d" % (i + 1, len(blocks)), end="\r")
                     with open(out_file_ts, "ab") as f:
                         f.write(downloaded_block)
-                os.system('ffmpeg -y -hide_banner -loglevel panic -i "%s" -c copy "%s"' % (out_file_ts, out_file_mp3))
+                os.system('ffmpeg -y -hide_banner -loglevel panic -i "%s" -metadata title="%s" -metadata artist="%s" -c copy "%s"' % (out_file_ts, title, artist, out_file_mp3))
                 print("\nConverted to mp3")
                 os.remove(out_file_ts)
         else:

--- a/vkaudio.py
+++ b/vkaudio.py
@@ -55,7 +55,7 @@ for s in sections:
         break
 print('Default section: "%s": %s: %s' % (music_section["title"], music_section["id"], music_section["url"]))
 next_start = music_section.get("next_from")
-while next_start:
+while :
     # print("Next from:", next_start)
     resp = vk.request("catalog.getSection", {"start_from": next_start, "section_id": music_section["id"]})
     next_start = resp["section"].get("next_from")
@@ -77,16 +77,35 @@ if dump:
     sys.exit()
 while True:
     download_all = False
+    download_range = False
     task = []
-    user_input = input("Select track (a = all / q to exit): ")
+    user_input = input("Select track (e.g. 1 or 1,2,3 or 1-5,7,9 / a = all / q to exit): ")
     if user_input == "q":
         break
     if user_input == "a":
         task = audios
         download_all = True
     elif not user_input.isnumeric():
-        print("Enter number")
-        continue
+        parse_in = user_input.split(",")
+        parse_good = True
+        for el in parse_in:
+            if "-" in el:
+                rng = el.split("-")
+                if len(rng) != 2 or not (rng[0].isnumeric() and rng[1].isnumeric()):
+                    print("Incorrect range input format")
+                    parse_good = False
+                    break
+                for i in range(int(rng[0]), int(rng[1])+1):
+                    task.append(audios[i])
+            elif el.isnumeric():
+                task.append(audios[int(el)])
+            else:
+                parse_good = False
+        if not parse_good:
+            print("Enter number, list of numbers or ranges")
+            continue
+        else:
+            download_range = True
     else:
         selected_id = int(user_input) - 1
         if selected_id + 1 > len(audios):
@@ -97,7 +116,7 @@ while True:
         artist = audio["artist"]
         title = audio["title"]
         track_name = "%s — %s" % (artist, title)
-        if download_all:
+        if download_all or download_range:
             result_number = n + 1
         else:
             result_number = int(user_input)

--- a/vkaudio.py
+++ b/vkaudio.py
@@ -55,7 +55,7 @@ for s in sections:
         break
 print('Default section: "%s": %s: %s' % (music_section["title"], music_section["id"], music_section["url"]))
 next_start = music_section.get("next_from")
-while :
+while next_start:
     # print("Next from:", next_start)
     resp = vk.request("catalog.getSection", {"start_from": next_start, "section_id": music_section["id"]})
     next_start = resp["section"].get("next_from")


### PR DESCRIPTION
These changes add support for input in format of comma-separated and dash-separated integers, e.g. entering `1-4,8-10,15,16` will download tracks 1, 2, 3, 4, 8, 9, 10, 15 and 16.